### PR TITLE
Github token should not be compiled with source code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ or download the appropriate file for your device from [releases](https://github.
 ### Building From Source
 
 To build and run Kusa in your own environment, 
-Put your Github Personal Access Token with "read:user" enabled in "GITHUB_ACCESS_TOKEN" (src/main.rs, line 9)
-```Rust
-static GITHUB_ACCESS_TOKEN : &str = "GITHUB_ACCESS_TOKEN";
+Assign your Github Personal Access Token with "read:user" in environment variable as
+```Bash
+GITHUB_TOKEN="<your_github_token>"
 ```
 then run this
+
+```Rust
+$ cargo run <github_user_name>
 ```
-$ cargo run <github user name>
+or run directly with
+```
+$ GITHUB_TOKEN=<your_github_token> cargo run <github_user_name>
 ```
 
 ## How To Generate A Github Access Token
@@ -51,10 +56,10 @@ Therefore, use iTerm2, Hyper, Warp or other terminals to display colors correctl
 ### `kusa --help`
 ```
 USAGE:
-    kusa <github user name>
+    kusa <github_user_name>
 
 ARGS:
-    <github user name>
+    <github_user_name>
 
 OPTIONS:
     -h, --help       Print help information

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use graphql_client::{reqwest::post_graphql_blocking as post_graphql, GraphQLQuery};
 use std::process;
-
-//////////////////////////////////////////////////////////
-static GITHUB_ACCESS_TOKEN : &str = "GITHUB_ACCESS_TOKEN";
-//////////////////////////////////////////////////////////
+use std::env;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -92,7 +89,7 @@ fn get_github_contributions(response_data: kusa::ResponseData) -> (i64, Vec<Vec<
     }
 }
 
-fn post_graphql_query(user_name: String) -> Result<kusa::ResponseData> {
+fn post_graphql_query(user_name: String, token: String) -> Result<kusa::ResponseData> {
 
     let variables = kusa::Variables { user_name };
 
@@ -101,7 +98,7 @@ fn post_graphql_query(user_name: String) -> Result<kusa::ResponseData> {
         .default_headers(
             std::iter::once((
                 reqwest::header::AUTHORIZATION,
-                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", GITHUB_ACCESS_TOKEN))
+                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))
                     .unwrap(),
             ))
             .collect(),
@@ -203,7 +200,9 @@ fn main() -> Result<()> {
 
     let args = Command::parse();
 
-    let data = post_graphql_query(args.user_name)?;
+    let token = env::var("GITHUB_TOKEN").unwrap();
+
+    let data = post_graphql_query(args.user_name,token)?;
     let (total_contributions, weekly_statuses) = get_github_contributions(data);
     let kusa = transpose(&weekly_statuses);
 


### PR DESCRIPTION
I am not a rust dev. But I don't think it's a good idea to compile github token altogether in the source code. 
This fix fetch GITHUB_TOKEN from environment variable.